### PR TITLE
Increase readTimeout in WebHandler

### DIFF
--- a/app/src/main/java/com/utazukin/ichaival/WebHandler.kt
+++ b/app/src/main/java/com/utazukin/ichaival/WebHandler.kt
@@ -65,12 +65,13 @@ object WebHandler : Preference.OnPreferenceChangeListener {
     private const val infoPath = "$apiPath/info"
     private const val categoryPath = "$apiPath/categories"
     private const val clearTempPath = "$apiPath/tempfolder"
-    private const val timeout = 5000L //ms
+    private const val connTimeoutMs = 5000L
+    private const val readTimeoutMs = 30000L
 
     var serverLocation: String = ""
     var apiKey: String = ""
     private val urlRegex by lazy { Regex("^(https?://|www\\.)?[a-z0-9-]+(\\.[a-z0-9-]+)*(:\\d+)?([/?].*)?\$") }
-    private val httpClient = OkHttpClient.Builder().connectTimeout(timeout, TimeUnit.MILLISECONDS).build()
+    private val httpClient = OkHttpClient.Builder().connectTimeout(connTimeoutMs, TimeUnit.MILLISECONDS).readTimeout(readTimeoutMs, TimeUnit.MILLISECONDS).build()
 
     var verboseMessages = false
     var listener: DatabaseMessageListener? = null


### PR DESCRIPTION
Requests to the `/api/archives` endpoint frequently takes over 10s to complete (the default okhttp read timeout), and are being dropped. For my instance, the request completes in around 9-12 seconds, making the issue intermittent. This PR increases the readTimeout to 30 seconds to account for more underpowered devices.