### PR TITLE
Compatible animated webp for Android versions below P

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -115,4 +115,9 @@ dependencies {
     implementation "io.coil-kt.coil3:coil-compose:$coil_version"
     implementation "io.coil-kt.coil3:coil-network-okhttp:$coil_version"
     implementation "com.drakeet.drawer:drawer:1.0.3"
+    // webpdecoder
+    implementation "com.github.zjupure:webpdecoder:2.7.$GLIDE_VERSION"
+    // glide 4.10.0+
+    implementation "com.github.bumptech.glide:glide:$GLIDE_VERSION"
+    annotationProcessor "com.github.bumptech.glide:compiler:$GLIDE_VERSION"
 }

--- a/app/src/main/java/com/utazukin/ichaival/GlideCompat.kt
+++ b/app/src/main/java/com/utazukin/ichaival/GlideCompat.kt
@@ -1,0 +1,58 @@
+package com.utazukin.ichaival
+
+import android.graphics.drawable.Animatable
+import android.graphics.drawable.Drawable
+import androidx.fragment.app.Fragment
+import android.view.View
+import com.bumptech.glide.Glide
+import com.bumptech.glide.load.DataSource
+import com.bumptech.glide.load.engine.GlideException
+import com.bumptech.glide.request.RequestListener
+import com.bumptech.glide.request.target.Target
+import java.io.File
+
+/**
+ * Helper to load animated WebP via Glide for pre-P devices.
+ * Calls [onReady] on success and [onError] on failure. The drawable
+ * will be set into [imageView] by Glide; if it's animatable it will be started.
+ */
+fun loadAnimatedWebpWithGlide(
+    fragment: Fragment,
+    imageView: android.view.View,
+    imageFile: File,
+    onReady: (() -> Unit)? = null,
+    onError: (() -> Unit)? = null
+) {
+    // PhotoView extends ImageView, so it's safe to cast at call sites
+    Glide.with(fragment)
+        .load(imageFile)
+        .listener(object : RequestListener<Drawable?> {
+            override fun onLoadFailed(
+                e: GlideException?,
+                model: Any?,
+                target: Target<Drawable?>,
+                isFirstResource: Boolean
+            ): Boolean {
+                onError?.invoke()
+                return true
+            }
+
+            override fun onResourceReady(
+                resource: Drawable,
+                model: Any,
+                target: Target<Drawable?>?,
+                dataSource: DataSource,
+                isFirstResource: Boolean
+            ): Boolean {
+                onReady?.invoke()
+                if (resource is Animatable) {
+                    try {
+                        resource.start()
+                    } catch (_: Exception) {}
+                }
+                // Return false so Glide will set the drawable on the view.
+                return false
+            }
+        })
+        .into(imageView as android.widget.ImageView)
+}

--- a/app/src/main/java/com/utazukin/ichaival/HelperFunctions.kt
+++ b/app/src/main/java/com/utazukin/ichaival/HelperFunctions.kt
@@ -177,10 +177,7 @@ private fun ByteArray.isAscii(offset: Int, value: String) : Boolean {
     return true
 }
 
-fun isSupportedAnimatedWebp(imageFile: File) : Boolean {
-    // Only Android 9+ (API 28) natively supports animated webp
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) return false
-
+fun isAnimatedWebp(imageFile: File) : Boolean {
     val header = ByteArray(32)
     val bytesRead = imageFile.inputStream().use { it.read(header) }
     if (bytesRead < header.size)
@@ -193,7 +190,7 @@ fun isSupportedAnimatedWebp(imageFile: File) : Boolean {
 }
 
 fun isAnimatedImage(imageFile: File) : Boolean {
-    return getImageFormat(imageFile) == ImageFormat.GIF || isSupportedAnimatedWebp(imageFile)
+    return getImageFormat(imageFile) == ImageFormat.GIF || isAnimatedWebp(imageFile)
 }
 
 fun SubsamplingScaleImageView.setDefaultScale() {

--- a/app/src/main/java/com/utazukin/ichaival/reader/ReaderFragment.kt
+++ b/app/src/main/java/com/utazukin/ichaival/reader/ReaderFragment.kt
@@ -23,6 +23,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.res.Configuration
 import android.graphics.PointF
+import android.os.Build
 import android.os.Bundle
 import android.view.GestureDetector
 import android.view.LayoutInflater
@@ -46,7 +47,6 @@ import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView
 import com.github.chrisbanes.photoview.PhotoView
 import com.utazukin.ichaival.Archive
 import com.utazukin.ichaival.ImageDecoder
-import com.utazukin.ichaival.ImageFormat
 import com.utazukin.ichaival.ImageRegionDecoder
 import com.utazukin.ichaival.R
 import com.utazukin.ichaival.cacheOrGet
@@ -55,7 +55,9 @@ import com.utazukin.ichaival.downloadCoilImageWithProgress
 import com.utazukin.ichaival.getImageFormat
 import com.utazukin.ichaival.getMaxTextureSize
 import com.utazukin.ichaival.isAnimatedImage
+import com.utazukin.ichaival.isAnimatedWebp
 import com.utazukin.ichaival.isLocalFile
+import com.utazukin.ichaival.loadAnimatedWebpWithGlide
 import com.utazukin.ichaival.setDefaultScale
 import kotlinx.coroutines.launch
 import java.io.File
@@ -172,10 +174,27 @@ class ReaderFragment : Fragment(), PageFragment {
             mainImage = if (isAnimatedImage(imageFile)) {
                 PhotoView(activity).also {
                     initializeView(it)
-                    it.load(imageFile, gifLoader) {
-                        diskCacheKey(image)
-                        size(Dimension.Undefined, Dimension.Undefined)
-                        listener(
+                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P && isAnimatedWebp(imageFile)) {
+                        // Use Glide fallback helper for animated WebP on older Android
+                        loadAnimatedWebpWithGlide(
+                            this@ReaderFragment,
+                            it,
+                            imageFile,
+                            onReady = {
+                                pageNum.visibility = View.GONE
+                                view?.run {
+                                    setOnClickListener(null)
+                                    setOnLongClickListener(null)
+                                }
+                                progressBar.visibility = View.GONE
+                            },
+                            onError = { showErrorMessage() }
+                        )
+                    } else {
+                        it.load(imageFile, gifLoader) {
+                            diskCacheKey(image)
+                            size(Dimension.Undefined, Dimension.Undefined)
+                            listener(
                                 onSuccess = { _, _ ->
                                     pageNum.visibility = View.GONE
                                     view?.run {
@@ -185,7 +204,8 @@ class ReaderFragment : Fragment(), PageFragment {
                                     progressBar.visibility = View.GONE
                                 },
                                 onError = { _, _ -> showErrorMessage() }
-                        )
+                            )
+                        }
                     }
                 }
             } else {
@@ -220,7 +240,6 @@ class ReaderFragment : Fragment(), PageFragment {
                 }
             }.also { setupImageTapEvents(it) }
         }
-
     }
 
     private fun initializeView(view: View) {

--- a/app/src/main/java/com/utazukin/ichaival/reader/ReaderMultiPageFragment.kt
+++ b/app/src/main/java/com/utazukin/ichaival/reader/ReaderMultiPageFragment.kt
@@ -23,6 +23,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.PointF
+import android.os.Build
 import android.os.Bundle
 import android.util.Size
 import android.view.GestureDetector
@@ -54,7 +55,6 @@ import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView
 import com.github.chrisbanes.photoview.PhotoView
 import com.utazukin.ichaival.Archive
 import com.utazukin.ichaival.ImageDecoder
-import com.utazukin.ichaival.ImageFormat
 import com.utazukin.ichaival.ImageRegionDecoder
 import com.utazukin.ichaival.R
 import com.utazukin.ichaival.cacheOrGet
@@ -63,7 +63,9 @@ import com.utazukin.ichaival.downloadCoilImageWithProgress
 import com.utazukin.ichaival.getImageFormat
 import com.utazukin.ichaival.getMaxTextureSize
 import com.utazukin.ichaival.isAnimatedImage
+import com.utazukin.ichaival.isAnimatedWebp
 import com.utazukin.ichaival.isLocalFile
+import com.utazukin.ichaival.loadAnimatedWebpWithGlide
 import com.utazukin.ichaival.outSize
 import com.utazukin.ichaival.setDefaultScale
 import com.utazukin.ichaival.tryOrNull
@@ -265,9 +267,25 @@ class ReaderMultiPageFragment : Fragment(), PageFragment {
             mainImage = if (isAnimatedImage(imageFile)) {
                 PhotoView(activity).also {
                     initializeView(it)
-                    it.load(imageFile, gifLoader) {
-                        size(Dimension.Undefined, Dimension.Undefined)
-                        listener(
+                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P && isAnimatedWebp(imageFile)) {
+                        loadAnimatedWebpWithGlide(
+                            this@ReaderMultiPageFragment,
+                            it,
+                            imageFile,
+                            onReady = {
+                                pageNum.visibility = View.GONE
+                                view?.run {
+                                    setOnClickListener(null)
+                                    setOnLongClickListener(null)
+                                }
+                                progressBar.visibility = View.GONE
+                            },
+                            onError = { showErrorMessage() }
+                        )
+                    } else {
+                        it.load(imageFile, gifLoader) {
+                            size(Dimension.Undefined, Dimension.Undefined)
+                            listener(
                                 onSuccess = { _, _ ->
                                     pageNum.visibility = View.GONE
                                     view?.run {
@@ -277,7 +295,8 @@ class ReaderMultiPageFragment : Fragment(), PageFragment {
                                     progressBar.visibility = View.GONE
                                 },
                                 onError = { _, _ -> showErrorMessage() }
-                        )
+                            )
+                        }
                     }
                 }
             } else {

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
     ext.coroutine_version = "1.10.1"
     ext.coil_version = '3.0.4'
     ext.room_version = "2.6.1"
+    ext.GLIDE_VERSION = "4.16.0"
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
Hi! This PR adds glidewebpdecoder to support animated WebP on Android versions below P. It’s a lightweight decoder that works with Glide, so older devices can still play animated WebP images smoothly.
If it fits the project direction, feel free to merge — otherwise, no pressure at all. 